### PR TITLE
chore: ignore the external pkg downloaded and donot commit to repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules
+
+# Ignore the following as its an external package and autodownloaded on install
+src\cometchat-pro-react-ui-kit


### PR DESCRIPTION
Added a folder into the `.gitignore`, so that externally downloaded pkg can be ignored in the commit.